### PR TITLE
fix: Adapted yaml config initializer to a config file

### DIFF
--- a/stable_diffusion/config.py
+++ b/stable_diffusion/config.py
@@ -2,16 +2,6 @@ import model.unet as unet
 import model.clip_embedder as clip_embedder
 import model.autoencoder as autoencoder
 
-'''
-unet_model: UNetModel,
-                 autoencoder: Autoencoder,
-                 clip_embedder: CLIPTextEmbedder,
-                 latent_scaling_factor: float,
-                 n_steps: int,
-                 linear_start: float,
-                 linear_end: float,
-'''
-
 
 class Config:
     UNET_PARAMS = {

--- a/stable_diffusion/config.py
+++ b/stable_diffusion/config.py
@@ -1,0 +1,109 @@
+import model.unet as unet
+import model.clip_embedder as clip_embedder
+import model.autoencoder as autoencoder
+
+'''
+unet_model: UNetModel,
+                 autoencoder: Autoencoder,
+                 clip_embedder: CLIPTextEmbedder,
+                 latent_scaling_factor: float,
+                 n_steps: int,
+                 linear_start: float,
+                 linear_end: float,
+'''
+
+
+class Config:
+    UNET_PARAMS = {
+        "image_size": 32,
+        "in_channels": 4,
+        "out_channels": 4,
+        "model_channels": 320,
+        "attention_resolutions": [
+            4,
+            2,
+            1
+        ],
+        "num_res_blocks": 2,
+        "channel_mult": [
+            1,
+            2,
+            4,
+            4
+        ],
+        "num_heads": 8,
+        "use_spatial_transformer": True,
+        "transformer_depth": 1,
+        "context_dim": 768,
+        "use_checkpoint": True,
+        "legacy": False
+    }
+
+    AUTO_ENCODER_PARAMS = {
+        "embed_dim": 4,
+        "monitor": "val/rec_loss",
+        "ddconfig": {
+            "double_z": True,
+            "z_channels": 4,
+            "resolution": 256,
+            "in_channels": 3,
+            "out_ch": 3,
+            "ch": 128,
+            "ch_mult": [
+                1,
+                2,
+                4,
+                4
+            ],
+            "num_res_blocks": 2,
+            "attn_resolutions": [],
+            "dropout": 0
+        },
+        "lossconfig": {
+            "target": "torch.nn.Identity"
+        }
+    }
+
+
+    @property
+    def params(self):
+        unet_model = unet.UNetModel(
+            in_channels=self.UNET_PARAMS["in_channels"],
+            out_channels=self.UNET_PARAMS["out_channels"],
+            channels=self.UNET_PARAMS["model_channels"],
+            n_res_blocks=self.UNET_PARAMS["num_res_blocks"],
+            attention_levels=self.UNET_PARAMS["attention_resolutions"],
+            channel_multipliers=self.UNET_PARAMS["channel_mult"],
+            n_heads=self.UNET_PARAMS["num_heads"],
+            tf_layers=self.UNET_PARAMS["transformer_depth"],
+            d_cond=self.UNET_PARAMS["context_dim"],
+        )
+
+        autoencoder_model = autoencoder.Autoencoder(
+            encoder=autoencoder.Encoder(
+                channels=self.AUTO_ENCODER_PARAMS["ddconfig"]["ch"],
+                channel_multipliers=self.AUTO_ENCODER_PARAMS["ddconfig"]["ch_mult"],
+                n_resnet_blocks=self.AUTO_ENCODER_PARAMS["ddconfig"]["num_res_blocks"],
+            ),
+            decoder=autoencoder.Decoder(
+                channels=self.AUTO_ENCODER_PARAMS["ddconfig"]["ch"],
+                channel_multipliers=self.AUTO_ENCODER_PARAMS["ddconfig"]["ch_mult"],
+                n_resnet_blocks=self.AUTO_ENCODER_PARAMS["ddconfig"]["num_res_blocks"],
+                out_channels=self.AUTO_ENCODER_PARAMS["ddconfig"]["out_ch"],
+                z_channels=self.AUTO_ENCODER_PARAMS["ddconfig"]["z_channels"],
+            ),
+            emb_channels=self.AUTO_ENCODER_PARAMS["embed_dim"],
+            z_channels=self.AUTO_ENCODER_PARAMS["ddconfig"]["z_channels"],
+        )
+
+        clip_embedder_model = clip_embedder.CLIPTextEmbedder()
+
+        return {
+            "linear_start": 0.00085,
+            "linear_end": 0.012,
+            "n_steps": 1,
+            "latent_scaling_factor": 0.18215,
+            "unet_model": unet_model,
+            "autoencoder": autoencoder_model,
+            "clip_embedder": clip_embedder_model,
+        }

--- a/stable_diffusion/inference.py
+++ b/stable_diffusion/inference.py
@@ -11,6 +11,8 @@ from PIL import Image
 from einops import rearrange
 from pytorch_lightning import seed_everything
 from contextlib import nullcontext
+from config import Config
+import latent_diffusion as ldm
 
 #from ldm.util import instantiate_from_config
 
@@ -25,33 +27,16 @@ if USE_LDM:
 #ldm
 import importlib
 def get_obj_from_str(string, reload=False):
-    module, cls = string.rsplit(".", 1)
-    if reload:
-        module_imp = importlib.import_module(module)
-        importlib.reload(module_imp)
-    #wtf
-    print("get_obj_from_str: module= " + module)
-    print("get_obj_from_str: cls= " + cls)
-    #wtf is this doing
+    ## full function path = ldm.models.diffusion.ddpm.LatentDiffusion, do not use params
+    params = Config.params
 
-    print("get_obj_from_str: Attempting to Import " + module)
-    #imports = importlib.import_module(module, package=None)
-    #imports = None=
-    #return getattr(imports, cls)
-    return None
+    return ldm.LatentDiffusion(**params)
 
 #copied from 
 # https://huggingface.co/spaces/multimodalart/latentdiffusion/blob/main/latent-diffusion/ldm/util.py
 #ldm
-def instantiate_from_config(config):
-    if not "target" in config:
-        if config == '__is_first_stage__':
-            return None
-        elif config == "__is_unconditional__":
-            return None
-        raise KeyError("Expected key `target` to instantiate.")
-    print("instantiate_from_config: params= " + str(config.get("params", dict())) )
-    return get_obj_from_str(config["target"])(**config.get("params", dict()))
+def instantiate():
+    return get_obj_from_str()
 
 
 from transformers import logging
@@ -122,7 +107,7 @@ def seed_post(device):
 def load_model(config, ckpt=CHECKPOINT):
     pl_sd = torch.load(ckpt, map_location='cpu')
     sd = pl_sd['state_dict']
-    model = instantiate_from_config(config.model)
+    model = instantiate()
     model.load_state_dict(sd, strict=False)
     return model
 

--- a/stable_diffusion/latent_diffusion.py
+++ b/stable_diffusion/latent_diffusion.py
@@ -26,9 +26,9 @@ from typing import List
 import torch
 import torch.nn as nn
 
-from labml_nn.diffusion.stable_diffusion.model.autoencoder import Autoencoder
-from labml_nn.diffusion.stable_diffusion.model.clip_embedder import CLIPTextEmbedder
-from labml_nn.diffusion.stable_diffusion.model.unet import UNetModel
+from model.autoencoder import Autoencoder
+from model.clip_embedder import CLIPTextEmbedder
+from model.unet import UNetModel
 
 
 class DiffusionWrapper(nn.Module):


### PR DESCRIPTION
**What was done?**

- First, converted the yaml to json;
- Copied this json as a Python object
- Stored in a config file adapting the imports, param names and instantiated the classes using this parameters
- Instead of rewriting everything, just omitted the parameters from the get_obj_from_str, not using importlib anymore. It just generates the file.
