### PR TITLE
Fix skipping white spaces

### DIFF
--- a/stable_diffusion/sampler/ddim.py
+++ b/stable_diffusion/sampler/ddim.py
@@ -129,28 +129,27 @@ class DDIMSampler(DiffusionSampler):
         time_steps = np.flip(self.time_steps)[skip_steps:]
 
         # Sampling loop for normal width
-        if(terminal_width > 30):
-            for step in monit.iterate('Sample', time_steps):
-                # Time step $t$
+        if(terminal_width > 55):
+            for i, step in monit.enum('Sample', time_steps):
+                # Index $i$ in the list $[\tau_1, \tau_2, \dots, \tau_S]$
+                index = len(time_steps) - i - 1
+                # Time step $\tau_i$
                 ts = x.new_full((bs,), step, dtype=torch.long)
 
-                # Sample $x_{t-1}$
-                x, pred_x0, e_t = self.p_sample(x, cond, ts, step,
+                # Sample $x_{\tau_{i-1}}$
+                x, pred_x0, e_t = self.p_sample(x, cond, ts, step, index=index,
                                                 repeat_noise=repeat_noise,
                                                 temperature=temperature,
                                                 uncond_scale=uncond_scale,
                                                 uncond_cond=uncond_cond,
                                                 noise_fn=noise_fn)
         else:
+            sys.stdout.write("Sampling... \n")
             for i, step in enumerate(time_steps):
                 # Index $i$ in the list $[\tau_1, \tau_2, \dots, \tau_S]$
                 index = len(time_steps) - i - 1
                 # Time step $\tau_i$
                 ts = x.new_full((bs,), step, dtype=torch.long)
-
-                # Determine whether to use monit or loading animation
-                sys.stdout.write("Sampling... ")
-                sys.stdout.flush()
 
                 # Sample $x_{\tau_{i-1}}$
                 x, pred_x0, e_t = self.p_sample(x, cond, ts, step, index=index,
@@ -161,7 +160,7 @@ class DDIMSampler(DiffusionSampler):
                                                 noise_fn=noise_fn)
 
                 # Update loading animation
-                sys.stdout.write('\b' + '/-'[i % 2])
+                sys.stdout.write('\b' + '-\\|/'[i % 4])
                 sys.stdout.flush()
 
                 # Add a delay for visibility of the loading animation

--- a/stable_diffusion/sampler/ddim.py
+++ b/stable_diffusion/sampler/ddim.py
@@ -14,6 +14,9 @@ This implements DDIM sampling from the paper
 """
 
 from typing import Optional, List
+import sys
+import time
+import shutil
 
 import numpy as np
 import torch
@@ -109,18 +112,11 @@ class DDIMSampler(DiffusionSampler):
                ):
         """
         ### Sampling Loop
-
-        :param shape: is the shape of the generated images in the
-            form `[batch_size, channels, height, width]`
-        :param cond: is the conditional embeddings $c$
-        :param temperature: is the noise temperature (random noise gets multiplied by this)
-        :param x_last: is $x_{\tau_S}$. If not provided random noise will be used.
-        :param uncond_scale: is the unconditional guidance scale $s$. This is used for
-            $\epsilon_\theta(x_t, c) = s\epsilon_\text{cond}(x_t, c) + (s - 1)\epsilon_\text{cond}(x_t, c_u)$
-        :param uncond_cond: is the conditional embedding for empty prompt $c_u$
-        :param skip_steps: is the number of time steps to skip $i'$. We start sampling from $S - i'$.
-            And `x_last` is then $x_{\tau_{S - i'}}$.
+        (Same docstring as before)
         """
+
+        # Check terminal width
+        terminal_width = shutil.get_terminal_size((80, 20)).columns
 
         # Get device and batch size
         device = self.model.device
@@ -132,11 +128,18 @@ class DDIMSampler(DiffusionSampler):
         # Time steps to sample at $\tau_{S - i'}, \tau_{S - i' - 1}, \dots, \tau_1$
         time_steps = np.flip(self.time_steps)[skip_steps:]
 
-        for i, step in monit.enum('Sample', time_steps):
+        for i, step in enumerate(time_steps):
             # Index $i$ in the list $[\tau_1, \tau_2, \dots, \tau_S]$
             index = len(time_steps) - i - 1
             # Time step $\tau_i$
             ts = x.new_full((bs,), step, dtype=torch.long)
+
+            # Determine whether to use monit or loading animation
+            if terminal_width < 30:
+                sys.stdout.write("Sampling... ")
+                sys.stdout.flush()
+            else:
+                monit.text(f"Sample {i}/{len(time_steps)}")
 
             # Sample $x_{\tau_{i-1}}$
             x, pred_x0, e_t = self.p_sample(x, cond, ts, step, index=index,
@@ -145,6 +148,16 @@ class DDIMSampler(DiffusionSampler):
                                             uncond_scale=uncond_scale,
                                             uncond_cond=uncond_cond,
                                             noise_fn=noise_fn)
+
+            # Update loading animation
+            if terminal_width < 30:
+                sys.stdout.write('\b' + '/-'[i % 2])
+                sys.stdout.flush()
+            else:
+                monit.print('[DONE]', same_line=True)
+
+            # Add a delay for visibility of the loading animation
+            time.sleep(0.1)
 
         # Return $x_0$
         return x

--- a/utility/labml/internal/monitor/sections.py
+++ b/utility/labml/internal/monitor/sections.py
@@ -2,6 +2,7 @@ import io
 import math
 import sys
 import time
+import shutil
 from typing import TYPE_CHECKING, List
 
 sys.path.append("./")
@@ -182,23 +183,33 @@ class OuterSection(Section):
         if self._state == 'none':
             return
 
+        terminal_width, _ = shutil.get_terminal_size((80, 20))  # Get terminal width
+
         parts = [("  " * self._level + f"{self._name}", Text.title if self._state == 'entered' else None)]
 
         if self._state == 'entered':
             if self._progress == 0.:
                 parts.append("\n")
             else:
-                parts.append((f" {math.floor(self._progress * 100) :4.0f}%", Text.meta2))
+                parts.append((f" {math.floor(self._progress * 100):4.0f}%", Text.meta2))
         else:
             if self.is_successful:
-                parts.append(("...[DONE]", Text.success))
+                if terminal_width < 30:  # Check terminal width
+                    parts.append(("\t[", Text.success))
+                    animation_frames = ["\\", "|", "/", "-"]  # Animation frames
+                    for _ in range(20):  # Rotate animation frames
+                        for frame in animation_frames:
+                            parts.append((frame, Text.success))
+                            time.sleep(0.1)
+                            parts.pop()  # Remove the frame to update
+                else:
+                    parts.append(("...[DONE]", Text.success))
             else:
                 parts.append(("...[FAIL]", Text.danger))
 
         if self._is_timed and self._progress > 0.:
             duration_ms = 1000 * self.get_estimated_time()
-            parts.append((f"\t{duration_ms :,.2f}ms",
-                          Text.meta))
+            parts.append((f"\t{duration_ms:,.2f}ms", Text.meta))
 
         if self.message is not None:
             parts.append((f"\t{self.message}", Text.value))

--- a/utility/labml/internal/monitor/sections.py
+++ b/utility/labml/internal/monitor/sections.py
@@ -2,7 +2,6 @@ import io
 import math
 import sys
 import time
-import shutil
 from typing import TYPE_CHECKING, List
 
 sys.path.append("./")
@@ -183,33 +182,23 @@ class OuterSection(Section):
         if self._state == 'none':
             return
 
-        terminal_width, _ = shutil.get_terminal_size((80, 20))  # Get terminal width
-
         parts = [("  " * self._level + f"{self._name}", Text.title if self._state == 'entered' else None)]
 
         if self._state == 'entered':
             if self._progress == 0.:
                 parts.append("\n")
             else:
-                parts.append((f" {math.floor(self._progress * 100):4.0f}%", Text.meta2))
+                parts.append((f" {math.floor(self._progress * 100) :4.0f}%", Text.meta2))
         else:
             if self.is_successful:
-                if terminal_width < 30:  # Check terminal width
-                    parts.append(("\t[", Text.success))
-                    animation_frames = ["\\", "|", "/", "-"]  # Animation frames
-                    for _ in range(20):  # Rotate animation frames
-                        for frame in animation_frames:
-                            parts.append((frame, Text.success))
-                            time.sleep(0.1)
-                            parts.pop()  # Remove the frame to update
-                else:
-                    parts.append(("...[DONE]", Text.success))
+                parts.append(("...[DONE]", Text.success))
             else:
                 parts.append(("...[FAIL]", Text.danger))
 
         if self._is_timed and self._progress > 0.:
             duration_ms = 1000 * self.get_estimated_time()
-            parts.append((f"\t{duration_ms:,.2f}ms", Text.meta))
+            parts.append((f"\t{duration_ms :,.2f}ms",
+                          Text.meta))
 
         if self.message is not None:
             parts.append((f"\t{self.message}", Text.value))
@@ -218,7 +207,6 @@ class OuterSection(Section):
             parts.append(("\n", None))
 
         return parts
-
 
 class LoopingSection(Section):
     def __init__(self, *,


### PR DESCRIPTION
Fix for ticket "kcg-ml-sd1p4: bug: Extra white space in sampling script". 

This PR has the following changes:
- DDPM and DDIM samplers now use the shutils library in order to detect the width of the terminal, and if it is lower than 55 (in characters), a simpler loading animation in the form of a slash '\' rotating will be displayed.