### PR TITLE
adding --n-image-same-prompt, default 1

### DIFF
--- a/scripts/cli_builder.py
+++ b/scripts/cli_builder.py
@@ -174,6 +174,16 @@ class CLI:
         )
 
         return self
+    
+    def n_image_same_prompt(self):
+        self.parser.add_argument(
+            '--n-image-same-prompt',
+            type=int,
+            default=1,
+            help='How many images to generate for same prompt with different seeds (default: %(default)s)'
+        )
+
+        return self
 
     def seed(self):
         self.parser.add_argument(


### PR DESCRIPTION
added --n-image-same-prompt parameter (default 1) to define how many data items are generated for same prompt with different seeds.